### PR TITLE
Move PythonActivity from 'kivy' after 'renpy' drop

### DIFF
--- a/src/kivy_garden/xcamera/android_api.py
+++ b/src/kivy_garden/xcamera/android_api.py
@@ -4,7 +4,7 @@ from jnius import JavaException, PythonJavaClass, autoclass, java_method
 
 Camera = autoclass('android.hardware.Camera')
 AndroidActivityInfo = autoclass('android.content.pm.ActivityInfo')
-AndroidPythonActivity = autoclass('org.renpy.android.PythonActivity')
+AndroidPythonActivity = autoclass('org.kivy.android.PythonActivity')
 PORTRAIT = AndroidActivityInfo.SCREEN_ORIENTATION_PORTRAIT
 LANDSCAPE = AndroidActivityInfo.SCREEN_ORIENTATION_LANDSCAPE
 


### PR DESCRIPTION
org.renpy.android.PythonActivity is not working so it's needed to correct it with org.kivy.android.PythonActivity

But we have to be sure if this will not affect some other stuffs....