### PR TITLE
:arrow_up: Bumps to kivy post 2.0.0rc2 on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Change Log
 
+## [Unreleased]
+
+  - Increase test coverage to 93%
+  - Move PythonActivity from 'kivy' after 'renpy' drop, closes #15, refs #16
+  - Introduces GitHub actions, refs #18
+  - Also tests against Python 3.8, refs #19
+  - Android build CI, refs #20
+  - Uploads APK artifact, refs #21
+  - Automates PyPI releases from CI, refs #22
+  - Bumps to kivy post 2.0.0rc2 on Android, refs #23
+
 ## [2019.0928]
 
   - Setup coverage testing

--- a/buildozer.spec
+++ b/buildozer.spec
@@ -38,7 +38,7 @@ version.filename = %(source.dir)s/kivy_garden/xcamera/version.py
 # comma separated e.g. requirements = sqlite3,kivy
 requirements =
     android,
-    kivy==1.11.1,
+    kivy==00034a5,
     python3
 
 # (str) Custom source folders for requirements


### PR DESCRIPTION
Note we couldn't pin to `2.0.0rc2` as it's failing runtime with:
```
Run user program, change dir and execute entrypoint
 Traceback (most recent call last):
   File "/home/user/hostcwd/.buildozer/android/app/main.py", line 5, in <module>
   File "/home/user/hostcwd/.buildozer/android/app/kivy_garden/xcamera/__init__.py", line 15, in <module>
   File "/home/user/hostcwd/.buildozer/android/app/kivy_garden/xcamera/xcamera.py", line 4, in <module>
   File "/home/user/hostcwd/.buildozer/android/platform/build-armeabi-v7a/build/python-installs/xcamera/kivy/__init__.py", line 351, in <module>
 PermissionError: [Errno 13] Permission denied: '/data/.kivy'
Python for android ended.
```
This was fixed post rc2 via <https://github.com/kivy/kivy/pull/6852>